### PR TITLE
Fix and capture more metadata

### DIFF
--- a/lib/google-images-scraper.js
+++ b/lib/google-images-scraper.js
@@ -134,13 +134,15 @@ Scraper.prototype._links = function () {
 					var meta = JSON.parse($(this).parent().find('.rg_meta').text());
 
 					item = {
-						url: item.url,
-						thumb: meta.tu,
+						type: 'image/' + meta.ity,
 						width: meta.ow,
 						height: meta.oh,
-						format: meta.ity,
-						size: meta.os.match(/[-+]?(\d*[.])?\d+/)[0],
-						unit: meta.os.match(/\D+/).slice(-1)[0]	// make sure to select the last element
+						// size: meta.os.match(/[-+]?(\d*[.])?\d+/)[0], // fails query as property no longer exists
+						url: item.url,
+						thumb_url: meta.tu,
+						thumb_width: meta.tw,
+						thumb_height: meta.th
+						// unit: meta.os.match(/\D+/).slice(-1)[0] // fails query as property no longer exists
 					};
 
 					results.push(item);


### PR DESCRIPTION
`size` and `unit` no longer exist in Google search results, so .match was failing.

There was also more that could be captured.

This PR fixes the failing issue and captures more metadata.