### PR TITLE
Enable advanced search query

### DIFF
--- a/example.js
+++ b/example.js
@@ -10,10 +10,14 @@ var Scraper = require ('./index')
 google.list({
 	keyword: 'coca cola',
 	num: 10,
+	detail: true,
 	nightmare: {
 		show: true
-	}
-	//resolution:'l',
+	},
+  advanced: {
+    imgType: 'photo', // options: clipart, face, lineart, news, photo
+    resolution: undefined // options: l(arge), m(edium), i(cons), etc.
+  }
 })
 .then(function (res) {
 	console.log('first 10 results from google', res);

--- a/lib/google-images-scraper.js
+++ b/lib/google-images-scraper.js
@@ -27,7 +27,7 @@ Scraper.prototype.list = function (options) {
 	this.userAgent = options.userAgent || 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
 	this.noptions = options.nightmare || {};
 	this.timeout = options.timeout || 10000;
-	this.resolution = options.resolution || false; // l(arge) || m(edium) || i(cons)
+	this.advanced = options.advanced;
 
 	return new Promise.resolve(
 		self._links().bind(self).then(function (res) {
@@ -78,14 +78,21 @@ Scraper.prototype._extractUrl = function (item) {
 Scraper.prototype._links = function () {
 	var self = this;
 	var search_base = 'https://www.google.com/search?q=%&source=lnms&tbm=isch&sa=X';
-	if (this.resolution) search_base += '&tbs=isz:' + this.resolution;
+	if (this.advanced) {
+		var base = '&tbs=';
+		var build = [];
+		if (this.advanced.resolution) build.push('isz:'+this.advanced.resolution);
+		if (this.advanced.imgType) build.push('itp:'+this.advanced.imgType);
+		build = build.length > 1 ? build.join(',') : build[0];
+		search_base += '&tbs='+build;
+	}
 	return new Promise.resolve(
 		new Nightmare(self.noptions)
 			.useragent(self.userAgent)
 			.goto(search_base.replace('%', encodeURIComponent(self.keyword)))
 			.wait()
 			.inject('js', __dirname + '/jquery-2.1.4.min.js')
-
+			
 			.evaluate(function (timeout) {
 				$.data(document, 'timeout', false);
 				setTimeout(function () {


### PR DESCRIPTION
Turned `resolution` into a property of `advanced` query object for Google search.

Thus you can now search for a specific image type, such as "photo".

This allows you to to exclude clipart, lineart, etc.