### PR TITLE
Added color type advanced option to Google images scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# TODO
+add color type to advanced options
+
 # images-scraper
 This a simple way to scrape Google/Bing images using Nightmare and not be dependent on any API. The headless browser will just behave like a normal person, scroll and click. A rate limiter is implemented and can be used to prevent bans. Only the Google scraper uses a headless browser, the other providers use custom requests to generate the results.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# TODO
-add color type to advanced options
-
 # images-scraper
 This a simple way to scrape Google/Bing images using Nightmare and not be dependent on any API. The headless browser will just behave like a normal person, scroll and click. A rate limiter is implemented and can be used to prevent bans. Only the Google scraper uses a headless browser, the other providers use custom requests to generate the results.
 

--- a/example.js
+++ b/example.js
@@ -16,7 +16,8 @@ google.list({
 	},
   advanced: {
     imgType: 'photo', // options: clipart, face, lineart, news, photo
-    resolution: undefined // options: l(arge), m(edium), i(cons), etc.
+    resolution: undefined, // options: l(arge), m(edium), i(cons), etc.
+    color: undefined // options: color, gray, trans
   }
 })
 .then(function (res) {

--- a/lib/google-images-scraper.js
+++ b/lib/google-images-scraper.js
@@ -59,6 +59,9 @@ Scraper.prototype._links = function () {
 		if (this.advanced.imgType) { 
 			build.push('itp:'+this.advanced.imgType);
 		}
+		if (this.advanced.color) {
+			build.push('ic:'+this.advanced.color);
+		}
 
 		build = build.length > 1 ? build.join(',') : build[0];
 		search_base += '&tbs='+build;


### PR DESCRIPTION
![screenshot 2016-08-29 17 23 37](https://cloud.githubusercontent.com/assets/4610874/18056705/57544010-6e0d-11e6-9bd3-74034f68648a.png)

This is limited to the simple types, excluding specifying the color name to look for.