### PR TITLE
Documentation change and add title to results

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This a simple way to scrape Google images using Puppeteer. The headless browser 
 Give me the first 200 images of Banana's from Google (using headless browser)
 
 ```js
-var Scraper = require ('./index');
+var Scraper = require ('images-scraper');
 
 let google = new Scraper.Google({
 	keyword: 'banana',

--- a/lib/google-images-scraper.js
+++ b/lib/google-images-scraper.js
@@ -63,6 +63,7 @@ class Scraper {
 
 						var meta = JSON.parse($(element).parent().find('.rg_meta').text());
 						var item = {
+							title: meta.pt,
 							type: 'image/' + meta.ity,
 							width: meta.ow,
 							height: meta.oh,


### PR DESCRIPTION
Result titles are useful to get when processing images, added the key. I also changed the example code to point to the module directly rather than using an intermediate index file to reference it. This makes the sample that appears on npm's package repo stand-alone.