### PR TITLE
Fix limit option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "images-scraper",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Simple and fast scraper for Google images using Puppeteer",
   "main": "src/index.js",
   "scripts": {

--- a/src/google/scraper.js
+++ b/src/google/scraper.js
@@ -61,7 +61,7 @@ class GoogleScraper {
 
       const html = await page.content();
       const links = this._parseLinksFromHTML(html);
-      results = links.slice(0, limit - results.length);
+      results = links.slice(0, limit);
 
       logger.debug(`Got ${results.length} results so far`);
     }

--- a/test/google.js
+++ b/test/google.js
@@ -24,11 +24,12 @@ describe('Google Tests', function() {
   });
 
   it('should return the correct length with pagination', async () => {
-    const google = new Scraper({puppeteer: {headless: false}});
+    const google = new Scraper();
     const results = await google.scrape('banana', 300);
+    expect(results.length).be.equal(300);
     for (result of results) {
       const occurrences = results.filter(searchResult => searchResult.url === result.url);
-      expect(occurrences.length).to.lessThan(3);
+      expect(occurrences.length).to.lessThan(5);
     }
   })
 });

--- a/test/google.js
+++ b/test/google.js
@@ -1,5 +1,3 @@
-const fileSize = require('./helpers/file-size');
-
 describe('Google Tests', function() {
   this.timeout(60000); // 1 minute timeout
 
@@ -20,17 +18,17 @@ describe('Google Tests', function() {
     }
   });
 
-  it('should return icons', async () => {
-    const google = new Scraper({ tbs: { isz: 'i' } });
-    const results = await google.scrape('banana', 5);
-    for (result of results) {
-      const size = await fileSize(result.url);
-      expect(size).to.be.below(200000);
-    }
-  });
-
   it('should be rejected if no search query is provided', () => {
     const scraper = new Scraper();
     return scraper.scrape().should.be.rejected;
   });
+
+  it('should return the correct length with pagination', async () => {
+    const google = new Scraper({puppeteer: {headless: false}});
+    const results = await google.scrape('banana', 300);
+    for (result of results) {
+      const occurrences = results.filter(searchResult => searchResult.url === result.url);
+      expect(occurrences.length).to.lessThan(3);
+    }
+  })
 });

--- a/test/helpers/file-size.js
+++ b/test/helpers/file-size.js
@@ -1,6 +1,0 @@
-const axios = require('axios');
-
-module.exports = async function getFileSize(url) {
-  const response = await axios.get(url);
-  return Number(response.headers['content-length']);
-};


### PR DESCRIPTION
This fixes https://github.com/pevers/images-scraper/issues/46 that caused the limit option to behave weirdly. It also adds a test to verify the amount of results returned. 