### PR TITLE
Fix infinite loop for large limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "images-scraper",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Simple and fast scraper for Google images using Puppeteer",
   "main": "src/index.js",
   "scripts": {

--- a/test/google.js
+++ b/test/google.js
@@ -31,5 +31,11 @@ describe('Google Tests', function() {
       const occurrences = results.filter(searchResult => searchResult.url === result.url);
       expect(occurrences.length).to.lessThan(5);
     }
+  });
+
+  it('should stop when the end is reached', async () => {
+    const google = new Scraper();
+    const results = await google.scrape('banana', 1000);
+    expect(results.length).be.lessThan(1000);
   })
 });


### PR DESCRIPTION
When searching for large limits the script doesn't always detect the end-of-page. Instead of looking for a possibly localized string, I quit when the amount of results doesn't increase. I increased the scroll page delay to wait for page load after a scroll. 

Related issue: https://github.com/pevers/images-scraper/issues/44