### PR TITLE
Fix JS injection delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "images-scraper",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Simple and fast scraper for Google images using Puppeteer",
   "main": "src/index.js",
   "scripts": {

--- a/src/google/scraper.js
+++ b/src/google/scraper.js
@@ -58,6 +58,7 @@ class GoogleScraper {
     while (results.length < limit) {
       await this._scrollToEnd(page);
       await this._clickAllImages(page);
+      await page.waitFor(200);  // Delay needed to inject the JS elements
 
       const html = await page.content();
       const links = this._parseLinksFromHTML(html);


### PR DESCRIPTION
Script didn't wait for JS injection of images. This will add a 200ms delay for the page to finish loading.