### PR TITLE
Quick fix for the google accept cookies page

### DIFF
--- a/src/google/scraper.js
+++ b/src/google/scraper.js
@@ -55,11 +55,8 @@ class GoogleScraper {
       waitUntil: 'networkidle0',
     });
     
-    //Google Accept All
-    //Search for the button with the text "Accept all"
     const [button] = await page.$x("//button[contains(., 'Accept all')]");
     if (button) {
-      //Press the button and wait till the page finishes loading
       await button.click();
       await page.waitForNavigation({
         waitUntil: 'networkidle0',

--- a/src/google/scraper.js
+++ b/src/google/scraper.js
@@ -54,6 +54,18 @@ class GoogleScraper {
     await page.goto(query, {
       waitUntil: 'networkidle0',
     });
+    
+    //Google Accept All
+    //Search for the button with the text "Accept all"
+    const [button] = await page.$x("//button[contains(., 'Accept all')]");
+    if (button) {
+      //Press the button and wait till the page finishes loading
+      await button.click();
+      await page.waitForNavigation({
+        waitUntil: 'networkidle0',
+      });
+    }
+    
     await page.setViewport({ width: 1920, height: 1080 });
     await page.setUserAgent(this.userAgent);
 


### PR DESCRIPTION
When you try to search, google will ask if you accept the cookies. As this page is not scrollable it will cancel and throw a "no results found" back.
I added a quick fix in line 60. Its certainly not the best approach but it at least makes the scraper work again.