### PR TITLE
Fixed Type Issue when recieving data from scrape.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export default class Scraper {
    * @param searchQuery the search query.
    * @param limit search limit, defaults to 100
    */
-  scrape(searchQuery: string | string[], limit?: number): Promise<Scraper.ScrapeResult>;
+  scrape(searchQuery: string | string[], limit?: number): Promise<Array<Scraper.ScrapeResult>>;
 }
 
 declare namespace Scraper {


### PR DESCRIPTION
The google.scrape would return an array of scrape data however it was previously typed as a single instance.
I just changed it to an array.