### PR TITLE
fix: wrongly typed response

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export default class Scraper {
    * @param searchQuery the search query.
    * @param limit search limit, defaults to 100
    */
-  scrape(searchQuery: string | string[], limit?: number): Promise<Scraper.ScrapeResult>;
+  scrape(searchQuery: string | string[], limit?: number): Promise<Array<Scraper.ScrapeResult>>;
 }
 
 declare namespace Scraper {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "images-scraper",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2809,7 +2809,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
@@ -3631,7 +3632,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {


### PR DESCRIPTION
## Summary of Pull Request
The result of the `scrape` function returns an array of scrape results:
```bash
$ node x/index.js
[
  {
    url: 'https://media.npr.org/assets/img/2020/11/06/b643279e-03ce-469f-95cc-f457758859f8-c4d30b79302ecae1bb7926c7d24fbebfedef72fb-s1100-c50.jpg',
    source: 'https://www.npr.org/2020/11/06/932178314/king-von-emerging-chicago-rapper-dead-at-26',
    title: 'King Von, Emerging Chicago Rapper, Dead At 26 : NPR'
  },
...
]
```

However, the type file (`index.d.ts`) states that it should return as just one result. This is simply just changing the type from  `Promise<Scraper.ScrapeResult>` to `Promise<Array<Scraper.ScrapeResult>>` to fix type errors when using typescript.

*(note: i dont know how to reopen a pr so i just made a new one)*