### PR TITLE
fix: another wrongly typed response

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export default class Scraper {
    * @param searchQuery the search query.
    * @param limit search limit, defaults to 100
    */
-  scrape(searchQuery: string | string[], limit?: number): Promise<Array<Scraper.ScrapeResult>>;
+  scrape(searchQuery: string | string[], limit?: number): Promise<Array<Scraper.ScrapeResult> | Scraper.MultipleScrapeResult>;
 }
 
 declare namespace Scraper {
@@ -72,5 +72,17 @@ declare namespace Scraper {
      * Title for an image.
      */
     title: string;
+  }
+
+  export interface MultipleScrapeResult {
+    /**
+     * The search term used to get the results.
+     */
+    query: string;
+
+    /**
+     * The results for the search term.
+     */
+    results: Array<ScrapeResult>;
   }
 }


### PR DESCRIPTION
## Summary of Pull Request
When providing an array to scrape, it returns something different than what is typed. This is almost an addition to my previous PR.
![image](https://user-images.githubusercontent.com/93608862/205376853-b237f336-4ab8-49b0-a97a-482c19e2c150.png)

```js
[
  {
    query: 'banana',
    images: [
      [Object], [Object], [Object]
    ]
  },
...
]
```
