### PR TITLE
🐞 FIX: check for "linkElementHref" variable before parsing as url bec…

### DIFF
--- a/src/google/scraper.js
+++ b/src/google/scraper.js
@@ -198,11 +198,13 @@ class GoogleScraper {
     $('#islrg div[jsaction][data-tbnid]').each(function (_i, containerElement) {
       const containerElement_ = $(containerElement);
       const linkElementHref = containerElement_.find("a[href^='/imgres']").attr('href');
-      const imageElementAlt = containerElement_.find('img').attr('alt');
-      const parsedLink = url.parse(linkElementHref, { parseQueryString: true });
-      const imageurl = parsedLink.query.imgurl;
-      const source = parsedLink.query.imgrefurl;
-      links.push({ url: imageurl, source, title: imageElementAlt });
+      if (linkElementHref) { // linkElementHref could be undefined
+        const imageElementAlt = containerElement_.find('img').attr('alt');
+        const parsedLink = url.parse(linkElementHref, { parseQueryString: true });
+        const imageurl = parsedLink.query.imgurl;
+        const source = parsedLink.query.imgrefurl;
+        links.push({ url: imageurl, source, title: imageElementAlt });
+      }
     });
 
     return links;


### PR DESCRIPTION
sometimes the linkElementHrefis undefined, maybe the structure of Google results changed a bit, and this is the reason for this issue [https://github.com/pevers/images-scraper/issues/88](https://github.com/pevers/images-scraper/issues/88) 